### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Default owner
+* @aviralgarg05
+
+# Core engine
+/nexum_core/ @aviralgarg05
+/nexum_cli/ @aviralgarg05
+
+# CI/CD
+/.github/ @aviralgarg05


### PR DESCRIPTION
This PR adds a .github/CODEOWNERS file to ensure PRs are automatically assigned to the correct reviewers.
closes #1
