### PR TITLE
Add CI Status Badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CI](https://github.com/aviralgarg05/NexumDB/actions/workflows/ci.yml/badge.svg)](https://github.com/aviralgarg05/NexumDB/actions/workflows/ci.yml)
+
 # NexumDB - AI-Native Database
 
 An innovative, open-source database that combines traditional SQL with AI-powered features including advanced query operators, natural language processing, semantic caching, and reinforcement learning-based query optimization.


### PR DESCRIPTION
This pull request adds a GitHub Actions CI status badge to the top of the README.md file.  
The badge displays the current status of the CI workflow and links directly to the GitHub Actions page for easier visibility.

Closes #5
