### PR TITLE
ci: disable PR auto commenter on pull requests

### DIFF
--- a/.github/workflows/pr-commenter.yml
+++ b/.github/workflows/pr-commenter.yml
@@ -1,8 +1,7 @@
 name: PR Auto Commenter
 
 on:
-    pull_request:
-        types: [opened, reopened]
+    workflow_dispatch:
 
 permissions:
     pull-requests: write


### PR DESCRIPTION
## Summary
- disable PR Auto Commenter for pull request events
- keep workflow manual-only via workflow_dispatch

## Why
- requested to remove auto commenter from all PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to require manual triggering instead of automatic execution on pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->