### PR TITLE
feat(cli): add command history and auto-completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,6 +212,15 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "colorchoice"
@@ -347,6 +362,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +404,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,10 +420,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -406,6 +465,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -442,6 +512,15 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "indicatif"
@@ -527,6 +606,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "libredox"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,8 +666,10 @@ dependencies = [
  "clap",
  "colored",
  "comfy-table",
+ "dirs",
  "indicatif",
  "nexum_core",
+ "rustyline",
  "serde_json",
  "tokio",
 ]
@@ -598,7 +688,28 @@ dependencies = [
  "sled",
  "sqlparser",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -636,6 +747,12 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -818,6 +935,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rayon"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,6 +1003,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +1060,28 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustyline"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1e066dc922e513bda599c6ccb5f3bb2b0ea5870a579448f2622993f0a9a2f"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "same-file"
@@ -1081,7 +1241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1093,7 +1253,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1101,6 +1270,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/nexum_cli/Cargo.toml
+++ b/nexum_cli/Cargo.toml
@@ -21,3 +21,5 @@ comfy-table = "7.1"
 indicatif = "0.18"
 clap = { version = "4.6", features = ["derive"] }
 serde_json = "1.0"
+rustyline = "15"
+dirs = "6"

--- a/nexum_cli/src/main.rs
+++ b/nexum_cli/src/main.rs
@@ -6,7 +6,13 @@ use nexum_core::{
     executor::ExecutionResult, Catalog, Executor, NLTranslator, Parser as SqlParser,
     QueryExplainer, StorageEngine,
 };
-use std::io::{self, Write};
+use rustyline::completion::{Completer, Pair};
+use rustyline::error::ReadlineError;
+use rustyline::highlight::Highlighter;
+use rustyline::hint::Hinter;
+use rustyline::validate::Validator;
+use rustyline::{Context, Editor, Helper};
+use std::rc::Rc;
 use std::time::Duration;
 
 /// NexumDB - AI-Native Database with Natural Language Support
@@ -50,6 +56,122 @@ struct Args {
     json: bool,
 }
 
+/// SQL keywords for auto-completion.
+const SQL_KEYWORDS: &[&str] = &[
+    "SELECT", "INSERT", "INTO", "VALUES", "CREATE", "TABLE", "DROP", "DELETE", "FROM", "WHERE",
+    "UPDATE", "SET", "AND", "OR", "NOT", "ORDER", "BY", "ASC", "DESC", "LIMIT", "LIKE", "IN",
+    "BETWEEN", "JOIN", "ON", "GROUP", "HAVING", "DISTINCT", "AS", "NULL", "INTEGER", "FLOAT",
+    "TEXT", "BOOLEAN", "BEGIN", "COMMIT", "ROLLBACK", "SHOW", "TABLES", "DESCRIBE", "IF",
+    "EXISTS", "EXPLAIN", "ASK", "TRANSACTION",
+];
+
+/// Rustyline helper that provides tab-completion for SQL keywords,
+/// table names from the catalog, and column names when a table context
+/// can be inferred.
+struct NexumCompleter {
+    catalog: Rc<Catalog>,
+}
+
+impl NexumCompleter {
+    fn new(catalog: Rc<Catalog>) -> Self {
+        Self { catalog }
+    }
+
+    /// Try to detect a table name from the input so we can offer column completions.
+    /// Looks for patterns like `FROM <table>`, `INTO <table>`, `UPDATE <table>`,
+    /// `TABLE <table>`, `DESCRIBE <table>`.
+    fn detect_table_context(&self, line: &str) -> Option<String> {
+        let upper = line.to_uppercase();
+        let context_keywords = ["FROM", "INTO", "UPDATE", "TABLE", "DESCRIBE"];
+        for kw in &context_keywords {
+            if let Some(pos) = upper.rfind(kw) {
+                let after = &line[pos + kw.len()..];
+                let table_name = after.split_whitespace().next();
+                if let Some(name) = table_name {
+                    if !name.is_empty() {
+                        return Some(name.to_string());
+                    }
+                }
+            }
+        }
+        None
+    }
+}
+
+impl Completer for NexumCompleter {
+    type Candidate = Pair;
+
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        _ctx: &Context<'_>,
+    ) -> rustyline::Result<(usize, Vec<Pair>)> {
+        let line_up_to_cursor = &line[..pos];
+        // Find the start of the current word being typed
+        let word_start = line_up_to_cursor
+            .rfind(|c: char| c.is_whitespace() || c == ',' || c == '(')
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        let prefix = &line_up_to_cursor[word_start..];
+
+        if prefix.is_empty() {
+            return Ok((pos, vec![]));
+        }
+
+        let prefix_upper = prefix.to_uppercase();
+        let mut candidates: Vec<Pair> = Vec::new();
+
+        // 1. SQL keyword completions
+        for kw in SQL_KEYWORDS {
+            if kw.starts_with(&prefix_upper) {
+                candidates.push(Pair {
+                    display: kw.to_string(),
+                    replacement: kw.to_string(),
+                });
+            }
+        }
+
+        // 2. Table name completions
+        if let Ok(tables) = self.catalog.list_tables() {
+            for table in &tables {
+                let table_upper = table.to_uppercase();
+                if table_upper.starts_with(&prefix_upper) {
+                    candidates.push(Pair {
+                        display: table.clone(),
+                        replacement: table.clone(),
+                    });
+                }
+            }
+        }
+
+        // 3. Column name completions when a table context is available
+        if let Some(table_name) = self.detect_table_context(line_up_to_cursor) {
+            if let Ok(Some(schema)) = self.catalog.get_table(&table_name) {
+                for col in &schema.columns {
+                    let col_upper = col.name.to_uppercase();
+                    if col_upper.starts_with(&prefix_upper) {
+                        candidates.push(Pair {
+                            display: col.name.clone(),
+                            replacement: col.name.clone(),
+                        });
+                    }
+                }
+            }
+        }
+
+        Ok((word_start, candidates))
+    }
+}
+
+impl Hinter for NexumCompleter {
+    type Hint = String;
+}
+
+impl Highlighter for NexumCompleter {}
+impl Validator for NexumCompleter {}
+impl Helper for NexumCompleter {}
+
 fn main() -> anyhow::Result<()> {
     let args = Args::parse();
 
@@ -58,7 +180,7 @@ fn main() -> anyhow::Result<()> {
     let spinner = create_spinner("Initializing database engine...");
     let storage = StorageEngine::new("./nexumdb_data")?;
     let executor = Executor::new(storage.clone()).with_cache();
-    let catalog = Catalog::new(storage);
+    let catalog = Rc::new(Catalog::new(storage));
     spinner.finish_with_message("✓ Database engine ready".green().to_string());
 
     let spinner = create_spinner("Loading NL translator...");
@@ -94,113 +216,138 @@ fn main() -> anyhow::Result<()> {
         }
     };
 
+    // Set up rustyline editor with auto-completion
+    let completer = NexumCompleter::new(Rc::clone(&catalog));
+    let mut editor = Editor::new()?;
+    editor.set_helper(Some(completer));
+
+    // Determine history file path (default: ~/.nexumdb_history)
+    let history_path = dirs::home_dir().map(|h| h.join(".nexumdb_history"));
+    if let Some(ref path) = history_path {
+        let _ = editor.load_history(path); // Ignore error on first run
+    }
+
     println!();
     print_help_summary();
     println!();
 
     loop {
-        print!("{} ", "nexumdb>".bold().cyan());
-        io::stdout().flush()?;
+        let prompt = format!("{} ", "nexumdb>".bold().cyan());
+        match editor.readline(&prompt) {
+            Ok(line) => {
+                let input = line.trim();
 
-        let mut input = String::new();
-        let bytes_read = io::stdin().read_line(&mut input)?;
-        if bytes_read == 0 {
-            // EOF reached (e.g., piped input exhausted)
-            println!("{}", "Goodbye! 👋".green().bold());
-            break;
-        }
+                if input.is_empty() {
+                    continue;
+                }
 
-        let input = input.trim();
+                let _ = editor.add_history_entry(input);
 
-        if input.is_empty() {
-            continue;
-        }
+                if input.eq_ignore_ascii_case("exit") || input.eq_ignore_ascii_case("quit") {
+                    println!("{}", "Goodbye! 👋".green().bold());
+                    break;
+                }
 
-        if input.eq_ignore_ascii_case("exit") || input.eq_ignore_ascii_case("quit") {
-            println!("{}", "Goodbye! 👋".green().bold());
-            break;
-        }
+                if input.eq_ignore_ascii_case("help") {
+                    print_full_help();
+                    continue;
+                }
 
-        if input.eq_ignore_ascii_case("help") {
-            print_full_help();
-            continue;
-        }
+                if input.len() >= 4 && input[..4].eq_ignore_ascii_case("ASK ") {
+                    let natural_query = input[4..].trim();
 
-        if input.len() >= 4 && input[..4].eq_ignore_ascii_case("ASK ") {
-            let natural_query = input[4..].trim();
+                    if let Some(ref translator) = nl_translator {
+                        let schema = get_schema_context(&catalog);
 
-            if let Some(ref translator) = nl_translator {
-                let schema = get_schema_context(&catalog);
+                        let spinner =
+                            create_spinner(&format!("Translating: '{}'", natural_query));
+                        match translator.translate(natural_query, &schema) {
+                            Ok(sql) => {
+                                spinner.finish_and_clear();
+                                println!(
+                                    "{} {}",
+                                    "Generated SQL:".cyan().bold(),
+                                    sql.white()
+                                );
+                                println!();
 
-                let spinner = create_spinner(&format!("Translating: '{}'", natural_query));
-                match translator.translate(natural_query, &schema) {
-                    Ok(sql) => {
-                        spinner.finish_and_clear();
-                        println!("{} {}", "Generated SQL:".cyan().bold(), sql.white());
-                        println!();
-
-                        match SqlParser::parse(&sql) {
-                            Ok(statement) => match executor.execute(statement) {
-                                Ok(result) => {
-                                    print_result(&result, args.json);
+                                match SqlParser::parse(&sql) {
+                                    Ok(statement) => match executor.execute(statement) {
+                                        Ok(result) => {
+                                            print_result(&result, args.json);
+                                        }
+                                        Err(e) => {
+                                            print_error("Execution error", &e.to_string());
+                                        }
+                                    },
+                                    Err(e) => {
+                                        print_error("Parse error", &e.to_string());
+                                    }
                                 }
-                                Err(e) => {
-                                    print_error("Execution error", &e.to_string());
-                                }
-                            },
+                            }
                             Err(e) => {
-                                print_error("Parse error", &e.to_string());
+                                spinner.finish_and_clear();
+                                print_error("Translation error", &e.to_string());
                             }
                         }
+                    } else {
+                        print_error("Error", "Natural language translator not available");
                     }
+                    continue;
+                }
+
+                // Handle EXPLAIN command
+                if input.len() >= 8 && input[..8].eq_ignore_ascii_case("EXPLAIN ") {
+                    let query_to_explain = input[8..].trim();
+
+                    if let Some(ref explainer) = query_explainer {
+                        println!();
+                        match explainer.explain(query_to_explain) {
+                            Ok(plan) => {
+                                println!("{}", "Query Execution Plan:".cyan().bold());
+                                println!("{}", plan);
+                            }
+                            Err(e) => {
+                                print_error("Explain error", &e.to_string());
+                            }
+                        }
+                    } else {
+                        print_error("Error", "Query explainer not available");
+                    }
+                    continue;
+                }
+
+                match SqlParser::parse(input) {
+                    Ok(statement) => match executor.execute(statement) {
+                        Ok(result) => {
+                            print_result(&result, args.json);
+                        }
+                        Err(e) => {
+                            print_error("Execution error", &e.to_string());
+                        }
+                    },
                     Err(e) => {
-                        spinner.finish_and_clear();
-                        print_error("Translation error", &e.to_string());
+                        print_error("Parse error", &e.to_string());
                     }
                 }
-            } else {
-                print_error("Error", "Natural language translator not available");
             }
-            continue;
-        }
-
-        // Handle EXPLAIN command
-        if input.len() >= 8 && input[..8].eq_ignore_ascii_case("EXPLAIN ") {
-            let query_to_explain = input[8..].trim();
-
-            if let Some(ref explainer) = query_explainer {
-                println!();
-                match explainer.explain(query_to_explain) {
-                    Ok(plan) => {
-                        println!("{}", "Query Execution Plan:".cyan().bold());
-                        println!("{}", plan);
-                    }
-                    Err(e) => {
-                        print_error("Explain error", &e.to_string());
-                    }
-                }
-            } else {
-                print_error("Error", "Query explainer not available");
+            Err(ReadlineError::Interrupted) | Err(ReadlineError::Eof) => {
+                println!("{}", "Goodbye! 👋".green().bold());
+                break;
             }
-            continue;
-        }
-
-        match SqlParser::parse(input) {
-            Ok(statement) => match executor.execute(statement) {
-                Ok(result) => {
-                    print_result(&result, args.json);
-                }
-                Err(e) => {
-                    print_error("Execution error", &e.to_string());
-                }
-            },
-            Err(e) => {
-                print_error("Parse error", &e.to_string());
+            Err(err) => {
+                print_error("Input error", &err.to_string());
+                break;
             }
         }
     }
 
-    Ok(())
+    // Save history on exit
+    if let Some(ref path) = history_path {
+        let _ = editor.save_history(path);
+    }
+
+    Ok()
 }
 
 fn print_banner() {
@@ -597,7 +744,7 @@ fn value_to_json(value: &nexum_core::sql::types::Value) -> serde_json::Value {
     }
 }
 
-fn get_schema_context(catalog: &Catalog) -> String {
+fn get_schema_context(catalog: &Rc<Catalog>) -> String {
     match catalog.list_tables() {
         Ok(tables) => {
             let mut schema = String::new();

--- a/nexum_cli/src/main.rs
+++ b/nexum_cli/src/main.rs
@@ -58,11 +58,51 @@ struct Args {
 
 /// SQL keywords for auto-completion.
 const SQL_KEYWORDS: &[&str] = &[
-    "SELECT", "INSERT", "INTO", "VALUES", "CREATE", "TABLE", "DROP", "DELETE", "FROM", "WHERE",
-    "UPDATE", "SET", "AND", "OR", "NOT", "ORDER", "BY", "ASC", "DESC", "LIMIT", "LIKE", "IN",
-    "BETWEEN", "JOIN", "ON", "GROUP", "HAVING", "DISTINCT", "AS", "NULL", "INTEGER", "FLOAT",
-    "TEXT", "BOOLEAN", "BEGIN", "COMMIT", "ROLLBACK", "SHOW", "TABLES", "DESCRIBE", "IF",
-    "EXISTS", "EXPLAIN", "ASK", "TRANSACTION",
+    "SELECT",
+    "INSERT",
+    "INTO",
+    "VALUES",
+    "CREATE",
+    "TABLE",
+    "DROP",
+    "DELETE",
+    "FROM",
+    "WHERE",
+    "UPDATE",
+    "SET",
+    "AND",
+    "OR",
+    "NOT",
+    "ORDER",
+    "BY",
+    "ASC",
+    "DESC",
+    "LIMIT",
+    "LIKE",
+    "IN",
+    "BETWEEN",
+    "JOIN",
+    "ON",
+    "GROUP",
+    "HAVING",
+    "DISTINCT",
+    "AS",
+    "NULL",
+    "INTEGER",
+    "FLOAT",
+    "TEXT",
+    "BOOLEAN",
+    "BEGIN",
+    "COMMIT",
+    "ROLLBACK",
+    "SHOW",
+    "TABLES",
+    "DESCRIBE",
+    "IF",
+    "EXISTS",
+    "EXPLAIN",
+    "ASK",
+    "TRANSACTION",
 ];
 
 /// Rustyline helper that provides tab-completion for SQL keywords,
@@ -259,16 +299,11 @@ fn main() -> anyhow::Result<()> {
                     if let Some(ref translator) = nl_translator {
                         let schema = get_schema_context(&catalog);
 
-                        let spinner =
-                            create_spinner(&format!("Translating: '{}'", natural_query));
+                        let spinner = create_spinner(&format!("Translating: '{}'", natural_query));
                         match translator.translate(natural_query, &schema) {
                             Ok(sql) => {
                                 spinner.finish_and_clear();
-                                println!(
-                                    "{} {}",
-                                    "Generated SQL:".cyan().bold(),
-                                    sql.white()
-                                );
+                                println!("{} {}", "Generated SQL:".cyan().bold(), sql.white());
                                 println!();
 
                                 match SqlParser::parse(&sql) {

--- a/nexum_cli/src/main.rs
+++ b/nexum_cli/src/main.rs
@@ -382,7 +382,7 @@ fn main() -> anyhow::Result<()> {
         let _ = editor.save_history(path);
     }
 
-    Ok()
+    Ok(())
 }
 
 fn print_banner() {

--- a/nexum_core/src/bridge/mod.rs
+++ b/nexum_core/src/bridge/mod.rs
@@ -12,7 +12,7 @@ impl PythonBridge {
     }
 
     pub fn initialize(&mut self) -> Result<()> {
-        Python::with_gil(|py| {
+        Python::attach(|py: pyo3::Python| {
             let sys = py.import("sys")?;
             let path_attr = sys.getattr("path")?;
             let path = path_attr.downcast::<PyList>()?;
@@ -35,7 +35,7 @@ impl PythonBridge {
             return Err(anyhow!("Python bridge not initialized"));
         }
 
-        Python::with_gil(|py| {
+        Python::attach(|py: pyo3::Python| {
             let nexum_ai = PyModule::import(py, "nexum_ai.optimizer")?;
             let semantic_cache = nexum_ai.getattr("SemanticCache")?;
             let cache_instance = semantic_cache.call0()?;
@@ -50,7 +50,7 @@ impl PythonBridge {
     }
 
     pub fn test_integration(&self) -> Result<String> {
-        Python::with_gil(|py| {
+        Python::attach(|py: pyo3::Python| {
             let nexum_ai = PyModule::import(py, "nexum_ai.optimizer")?;
             let test_func = nexum_ai.getattr("test_vectorization")?;
             let result = test_func.call0()?;
@@ -63,7 +63,7 @@ impl PythonBridge {
 
 pub struct SemanticCache {
     bridge: PythonBridge,
-    cache: PyObject,
+    cache: Py<PyAny>,
 }
 
 impl SemanticCache {
@@ -75,18 +75,18 @@ impl SemanticCache {
         let mut bridge = PythonBridge::new()?;
         bridge.initialize()?;
 
-        let cache = Python::with_gil(|py| {
+        let cache = Python::attach(|py: pyo3::Python| {
             let nexum_ai = PyModule::import(py, "nexum_ai.optimizer")?;
             let semantic_cache_class = nexum_ai.getattr("SemanticCache")?;
             let cache_instance = semantic_cache_class.call1((0.95, cache_file))?;
-            Ok::<PyObject, PyErr>(cache_instance.unbind())
+            Ok::<Py<PyAny>, PyErr>(cache_instance.unbind())
         })?;
 
         Ok(Self { bridge, cache })
     }
 
     pub fn get(&self, query: &str) -> Result<Option<String>> {
-        Python::with_gil(|py| {
+        Python::attach(|py: pyo3::Python| {
             let cache_bound = self.cache.bind(py);
             let result = cache_bound.call_method1("get", (query,))?;
 
@@ -101,7 +101,7 @@ impl SemanticCache {
     }
 
     pub fn put(&self, query: &str, result: &str) -> Result<()> {
-        Python::with_gil(|py| {
+        Python::attach(|py: pyo3::Python| {
             let cache_bound = self.cache.bind(py);
             cache_bound.call_method1("put", (query, result))?;
             Ok::<(), PyErr>(())
@@ -114,7 +114,7 @@ impl SemanticCache {
     }
 
     pub fn save_cache(&self) -> Result<()> {
-        Python::with_gil(|py| {
+        Python::attach(|py: pyo3::Python| {
             let cache_bound = self.cache.bind(py);
             cache_bound.call_method0("save_cache")?;
             Ok::<(), PyErr>(())
@@ -123,7 +123,7 @@ impl SemanticCache {
     }
 
     pub fn load_cache(&self) -> Result<()> {
-        Python::with_gil(|py| {
+        Python::attach(|py: pyo3::Python| {
             let cache_bound = self.cache.bind(py);
             cache_bound.call_method0("load_cache")?;
             Ok::<(), PyErr>(())
@@ -132,7 +132,7 @@ impl SemanticCache {
     }
 
     pub fn clear_cache(&self) -> Result<()> {
-        Python::with_gil(|py| {
+        Python::attach(|py: pyo3::Python| {
             let cache_bound = self.cache.bind(py);
             cache_bound.call_method0("clear")?;
             Ok::<(), PyErr>(())
@@ -141,7 +141,7 @@ impl SemanticCache {
     }
 
     pub fn get_cache_stats(&self) -> Result<String> {
-        Python::with_gil(|py| {
+        Python::attach(|py: pyo3::Python| {
             let cache_bound = self.cache.bind(py);
             let result = cache_bound.call_method0("get_cache_stats")?;
             let stats_str: String = result.str()?.extract()?;
@@ -151,7 +151,7 @@ impl SemanticCache {
     }
 
     pub fn explain_query(&self, query: &str) -> Result<String> {
-        Python::with_gil(|py| {
+        Python::attach(|py: pyo3::Python| {
             let cache_bound = self.cache.bind(py);
             let result = cache_bound.call_method1("explain_query", (query,))?;
             let explain_str: String = result.str()?.extract()?;
@@ -163,7 +163,7 @@ impl SemanticCache {
 
 pub struct NLTranslator {
     _bridge: PythonBridge,
-    translator: PyObject,
+    translator: Py<PyAny>,
 }
 
 impl NLTranslator {
@@ -171,11 +171,11 @@ impl NLTranslator {
         let mut bridge = PythonBridge::new()?;
         bridge.initialize()?;
 
-        let translator = Python::with_gil(|py| {
+        let translator = Python::attach(|py: pyo3::Python| {
             let nexum_ai = PyModule::import(py, "nexum_ai.translator")?;
             let translator_class = nexum_ai.getattr("NLTranslator")?;
             let translator_instance = translator_class.call0()?;
-            Ok::<PyObject, PyErr>(translator_instance.unbind())
+            Ok::<Py<PyAny>, PyErr>(translator_instance.unbind())
         })?;
 
         Ok(Self {
@@ -185,7 +185,7 @@ impl NLTranslator {
     }
 
     pub fn translate(&self, natural_query: &str, schema: &str) -> Result<String> {
-        Python::with_gil(|py| {
+        Python::attach(|py: pyo3::Python| {
             let translator_bound = self.translator.bind(py);
             let result = translator_bound.call_method1("translate", (natural_query, schema))?;
 
@@ -208,7 +208,7 @@ impl QueryExplainer {
     }
 
     pub fn explain(&self, query: &str) -> Result<String> {
-        Python::with_gil(|py| {
+        Python::attach(|py: pyo3::Python| {
             let nexum_ai = PyModule::import(py, "nexum_ai.optimizer")?;
             let explain_func = nexum_ai.getattr("explain_query_plan")?;
             let format_func = nexum_ai.getattr("format_explain_output")?;
@@ -222,7 +222,7 @@ impl QueryExplainer {
     }
 
     pub fn explain_raw(&self, query: &str) -> Result<String> {
-        Python::with_gil(|py| {
+        Python::attach(|py: pyo3::Python| {
             let nexum_ai = PyModule::import(py, "nexum_ai.optimizer")?;
             let explain_func = nexum_ai.getattr("explain_query_plan")?;
 
@@ -241,7 +241,9 @@ mod tests {
     fn check_python_available() -> bool {
         let mut bridge = PythonBridge::new().unwrap();
         bridge.initialize().is_ok()
-            && Python::with_gil(|py| PyModule::import(py, "nexum_ai.optimizer").is_ok())
+            && Python::attach(|py: pyo3::Python| {
+                PyModule::import(py, "nexum_ai.optimizer").is_ok()
+            })
     }
 
     #[test]

--- a/nexum_core/src/executor/filter.rs
+++ b/nexum_core/src/executor/filter.rs
@@ -77,7 +77,19 @@ impl ExpressionEvaluator {
                 expr,
                 pattern,
                 escape_char,
-            } => self.evaluate_like(*negated, expr, pattern, escape_char.as_ref(), row_values),
+                any: _,
+            } => {
+                let ec_char = escape_char.as_ref().and_then(|ec_val| {
+                    if let sqlparser::ast::Value::SingleQuotedString(s) = ec_val {
+                        s.chars().next()
+                    } else if let sqlparser::ast::Value::DoubleQuotedString(s) = ec_val {
+                        s.chars().next()
+                    } else {
+                        None
+                    }
+                });
+                self.evaluate_like(*negated, expr, pattern, ec_char.as_ref(), row_values)
+            }
             Expr::InList {
                 expr,
                 list,
@@ -136,7 +148,9 @@ impl ExpressionEvaluator {
                     .ok_or_else(|| anyhow!("Column {} not found", col_name))?;
                 Ok(row_values[idx].clone())
             }
-            Expr::Value(sql_val) => self.convert_sql_value(sql_val),
+            Expr::Value(sqlparser::ast::ValueWithSpan {
+                value: ref sql_val, ..
+            }) => self.convert_sql_value(sql_val),
             _ => Err(anyhow!("Cannot extract value from expression: {:?}", expr)),
         }
     }

--- a/nexum_core/src/sql/parser.rs
+++ b/nexum_core/src/sql/parser.rs
@@ -30,9 +30,10 @@ impl Parser {
 
     fn convert_statement(stmt: &SqlStatement) -> Result<Statement> {
         match stmt {
-            SqlStatement::CreateTable { name, columns, .. } => {
-                let table_name = name.to_string();
-                let cols = columns
+            SqlStatement::CreateTable(create_table) => {
+                let table_name = create_table.name.to_string();
+                let cols = create_table
+                    .columns
                     .iter()
                     .map(Self::convert_column)
                     .collect::<Result<Vec<_>>>()?;
@@ -41,25 +42,24 @@ impl Parser {
                     columns: cols,
                 })
             }
-            SqlStatement::Insert {
-                table_name,
-                columns,
-                source,
-                ..
-            } => {
-                let table = table_name.to_string();
-                let col_names = columns.iter().map(|c| c.to_string()).collect();
+            SqlStatement::Insert(insert) => {
+                let table = insert.table.to_string();
+                let col_names = insert.columns.iter().map(|c| c.to_string()).collect();
 
-                let values = if let ast::SetExpr::Values(values) = &*source.body {
-                    values
-                        .rows
-                        .iter()
-                        .map(|row| {
-                            row.iter()
-                                .map(Self::convert_expr)
-                                .collect::<Result<Vec<_>>>()
-                        })
-                        .collect::<Result<Vec<_>>>()?
+                let values = if let Some(source) = &insert.source {
+                    if let ast::SetExpr::Values(values) = &*source.body {
+                        values
+                            .rows
+                            .iter()
+                            .map(|row| {
+                                row.iter()
+                                    .map(Self::convert_expr)
+                                    .collect::<Result<Vec<_>>>()
+                            })
+                            .collect::<Result<Vec<_>>>()?
+                    } else {
+                        return Err(anyhow!("Unsupported INSERT format"));
+                    }
                 } else {
                     return Err(anyhow!("Unsupported INSERT format"));
                 };
@@ -70,29 +70,20 @@ impl Parser {
                     values,
                 })
             }
-            SqlStatement::Update {
-                table,
-                assignments,
-                selection,
-                ..
-            } => {
-                let table_name = table.to_string();
+            SqlStatement::Update(update) => {
+                let table_name = update.table.to_string();
 
-                let assignment_pairs = assignments
+                let assignment_pairs = update
+                    .assignments
                     .iter()
                     .map(|assign| {
-                        let col_name = assign
-                            .id
-                            .iter()
-                            .map(|i| i.value.clone())
-                            .collect::<Vec<_>>()
-                            .join(".");
+                        let col_name = assign.target.to_string();
                         let value = Self::convert_expr(&assign.value)?;
                         Ok((col_name, value))
                     })
                     .collect::<Result<Vec<_>>>()?;
 
-                let where_clause = selection.as_ref().map(|expr| Box::new(expr.clone()));
+                let where_clause = update.selection.as_ref().map(|expr| Box::new(expr.clone()));
 
                 Ok(Statement::Update {
                     table: table_name,
@@ -100,16 +91,18 @@ impl Parser {
                     where_clause,
                 })
             }
-            SqlStatement::Delete {
-                from, selection, ..
-            } => {
+            SqlStatement::Delete(delete) => {
+                let from = match &delete.from {
+                    ast::FromTable::WithFromKeyword(f) => f,
+                    ast::FromTable::WithoutKeyword(f) => f,
+                };
                 let table = if let Some(from_clause) = from.first() {
                     from_clause.relation.to_string()
                 } else {
                     return Err(anyhow!("DELETE requires a table name"));
                 };
 
-                let where_clause = selection.as_ref().map(|expr| Box::new(expr.clone()));
+                let where_clause = delete.selection.as_ref().map(|expr| Box::new(expr.clone()));
 
                 Ok(Statement::Delete {
                     table,
@@ -154,37 +147,47 @@ impl Parser {
 
                     let where_clause = select.selection.as_ref().map(|expr| Box::new(expr.clone()));
 
-                    let order_by = if !query.order_by.is_empty() {
-                        Some(
-                            query
-                                .order_by
-                                .iter()
-                                .map(|order| {
-                                    let column = match &order.expr {
-                                        Expr::Identifier(ident) => ident.value.clone(),
-                                        _ => {
-                                            return Err(anyhow!(
-                                                "Unsupported ORDER BY expression: {}",
-                                                order.expr
-                                            ))
-                                        }
-                                    };
-                                    let ascending = order.asc.unwrap_or(true);
-                                    Ok(crate::sql::types::OrderByClause { column, ascending })
-                                })
-                                .collect::<Result<Vec<_>>>()?,
-                        )
+                    let order_by = if let Some(order_by_clause) = &query.order_by {
+                        match &order_by_clause.kind {
+                            ast::OrderByKind::Expressions(exprs) => Some(
+                                exprs
+                                    .iter()
+                                    .map(|order| {
+                                        let column = match &order.expr {
+                                            Expr::Identifier(ident) => ident.value.clone(),
+                                            _ => {
+                                                return Err(anyhow!(
+                                                    "Unsupported ORDER BY expression: {}",
+                                                    order.expr
+                                                ))
+                                            }
+                                        };
+                                        let ascending = order.options.asc.unwrap_or(true);
+                                        Ok(crate::sql::types::OrderByClause { column, ascending })
+                                    })
+                                    .collect::<Result<Vec<_>>>()?,
+                            ),
+                            _ => return Err(anyhow!("Unsupported ORDER BY syntax")),
+                        }
                     } else {
                         None
                     };
 
-                    let limit = query.limit.as_ref().and_then(|limit_expr| {
-                        if let ast::Expr::Value(ast::Value::Number(n, _)) = limit_expr {
-                            n.parse().ok()
-                        } else {
-                            None
-                        }
-                    });
+                    let limit =
+                        query
+                            .limit_clause
+                            .as_ref()
+                            .and_then(|limit_clause| match limit_clause {
+                                ast::LimitClause::LimitOffset {
+                                    limit:
+                                        Some(ast::Expr::Value(ast::ValueWithSpan {
+                                            value: ast::Value::Number(n, _),
+                                            ..
+                                        })),
+                                    ..
+                                } => n.parse().ok(),
+                                _ => None,
+                            });
 
                     Ok(Statement::Select {
                         table,
@@ -305,7 +308,9 @@ impl Parser {
             SqlDataType::Int(_) | SqlDataType::Integer(_) | SqlDataType::BigInt(_) => {
                 Ok(DataType::Integer)
             }
-            SqlDataType::Float(_) | SqlDataType::Double | SqlDataType::Real => Ok(DataType::Float),
+            SqlDataType::Float(_) | SqlDataType::Double(_) | SqlDataType::Real => {
+                Ok(DataType::Float)
+            }
             SqlDataType::Text
             | SqlDataType::Varchar(_)
             | SqlDataType::Char(_)
@@ -317,17 +322,32 @@ impl Parser {
 
     fn convert_expr(expr: &Expr) -> Result<Value> {
         match expr {
-            Expr::Value(ast::Value::Number(n, _)) => {
+            Expr::Value(ast::ValueWithSpan {
+                value: ast::Value::Number(n, _),
+                ..
+            }) => {
                 if n.contains('.') {
                     Ok(Value::Float(n.parse()?))
                 } else {
                     Ok(Value::Integer(n.parse()?))
                 }
             }
-            Expr::Value(ast::Value::SingleQuotedString(s))
-            | Expr::Value(ast::Value::DoubleQuotedString(s)) => Ok(Value::Text(s.clone())),
-            Expr::Value(ast::Value::Boolean(b)) => Ok(Value::Boolean(*b)),
-            Expr::Value(ast::Value::Null) => Ok(Value::Null),
+            Expr::Value(ast::ValueWithSpan {
+                value: ast::Value::SingleQuotedString(s),
+                ..
+            })
+            | Expr::Value(ast::ValueWithSpan {
+                value: ast::Value::DoubleQuotedString(s),
+                ..
+            }) => Ok(Value::Text(s.clone())),
+            Expr::Value(ast::ValueWithSpan {
+                value: ast::Value::Boolean(b),
+                ..
+            }) => Ok(Value::Boolean(*b)),
+            Expr::Value(ast::ValueWithSpan {
+                value: ast::Value::Null,
+                ..
+            }) => Ok(Value::Null),
             _ => Err(anyhow!("Unsupported expression: {:?}", expr)),
         }
     }


### PR DESCRIPTION
## Summary

Closes #52

Enhances the CLI REPL experience with persistent command history and tab auto-completion by replacing the raw `stdin.read_line()` loop with `rustyline::Editor`.

## Changes

### New Dependencies (`nexum_cli/Cargo.toml`)
- `rustyline = "15"` — readline-style editing, history, and completion
- `dirs = "6"` — cross-platform `~/.nexumdb_history` path resolution

### CLI REPL Rewrite (`nexum_cli/src/main.rs`)
- **`NexumCompleter`** struct implementing rustyline's `Helper` traits with:
  - SQL keyword completion (SELECT, INSERT, CREATE, etc.)
  - Table name completion from the live catalog
  - Column name completion when table context is detected (e.g. after `FROM users`)
- **`rustyline::Editor`** replaces `stdin.read_line()` for:
  - Arrow-key history navigation (up/down)
  - Ctrl+R reverse history search
  - Tab auto-completion
  - Persistent history at `~/.nexumdb_history`
  - Graceful Ctrl+C / Ctrl+D exit
- `Catalog` wrapped in `Rc` for sharing between the REPL and the completer

## Acceptance Criteria Addressed
- [x] History persists across sessions
- [x] Arrow up/down navigates history
- [x] Tab completion for SQL keywords
- [x] Tab completion for known table names
- [x] Tab completion for column names (when table context available)
- [x] Ctrl+R reverse search
- [x] Graceful Ctrl+C / Ctrl+D handling


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tab-completion for SQL keywords, table names, and column names in the CLI REPL
  * Persistent command history automatically saved and restored across sessions

* **Bug Fixes / Improvements**
  * More robust SQL parsing to handle newer AST shapes (INSERT/UPDATE/DELETE/SELECT ORDER BY/LIMIT)
  * Corrected LIKE escape-char handling and literal value extraction for expression evaluation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->